### PR TITLE
Update vis_seg.py and lite repo readme file

### DIFF
--- a/lite/README.md
+++ b/lite/README.md
@@ -22,6 +22,8 @@ Sapiens-Lite is our optimized "inference-only" solution, offering:
   - `MODE=bfloat16`: Optimized mode for A100 GPUs with PyTorch2.2 or 2.3. Uses [FlashAttention](https://github.com/Dao-AILab/flash-attention) for accelerated inference. Coming Soon!
   - `MODE=float16`: Optimized mode for V100 GPUs with PyTorch2.2 or 2.3. Coming Soon!
 
+- Note to Windows users: installation instructions provided here will work, but you should use the python scripts in `./demo` instead of `./scripts`.
+
 - Please download the checkpoints from [hugging-face](https://huggingface.co/facebook/sapiens/tree/main/sapiens_lite_host).\
   Checkpoints are suffixed with "_$MODE.pt2".\
   You can be selective about only downloading the checkpoints of interest.\

--- a/lite/demo/vis_seg.py
+++ b/lite/demo/vis_seg.py
@@ -136,7 +136,7 @@ def main():
         "--batch_size",
         "--batch-size",
         type=int,
-        default=32,
+        default=4,
         help="Set batch size to do batch inference. ",
     )
     parser.add_argument(
@@ -208,6 +208,15 @@ def main():
         input_dir = (
             os.path.dirname(image_paths[0]) if image_paths else ""
         )  # Use the directory of the first image path
+    else:
+        raise ValueError("Invalid input, must be a directory or a text file")
+
+    if len(image_names) == 0:
+        raise ValueError("No images found in the input directory")
+
+    # If left unspecified, create an output folder relative to this script.
+    if args.output_root is None:
+        args.output_root = os.path.join(input_dir, "output")
 
     if not os.path.exists(args.output_root):
         os.makedirs(args.output_root)


### PR DESCRIPTION
- Mention windows users as the existing docs seem to imply a linux environment throughout (and scripts are .sh files)
- Add some error handling to `vis_seg.py`, and lower the default batch size to 4 (the existing default of 32 blew up my 4090 so the thought is anyone with a commercial card will likely know to boost this via commandline arguments). I also considered attempting to implement a batch_size=-1 to automatically change the batch size, but given the multi-gpu support in here seems like it might be a bigger undertaking than it would be for single gpu environments.

Note: if you like this change enough to merge, I'd be happy to add similar changes to the other scripts in `./demo`, just reply to this PR and let me know.